### PR TITLE
Update for GNOME 41

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -177,6 +177,7 @@ const MumblePingIndicator = GObject.registerClass(
                     this._log('Cancelled previous operation');
                     this._setIndicatorToError();
                 } else {
+                    this._connection = null;
                     this._handleError(error, '_mainLoop');
                 }
             }

--- a/icons/icon_neutral.svg
+++ b/icons/icon_neutral.svg
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    version="1"
    id="svg883"
-   sodipodi:docname="mumble_neutral_monochrome.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   sodipodi:docname="icon_neutral.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title199">icon_neutral.svg</title>
   <metadata
      id="metadata889">
     <rdf:RDF>
@@ -21,7 +23,21 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:source>https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/blob/77fad87146ce97ca76fa54379a6fe16545146ab4/Papirus/64x64/apps/mumble.svg</dc:source>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>PapirusDevelopmentTeam</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>icon_neutral.svg</dc:title>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>maweil</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:description>Modified version of PapirusDevelopmentTeam's mumble.svg icon (see source URL)</dc:description>
+        <cc:license
+           rdf:resource="https://spdx.org/licenses/GPL-3.0-or-later.html" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,12 +57,13 @@
      id="namedview885"
      showgrid="false"
      inkscape:zoom="11.671875"
-     inkscape:cx="32"
-     inkscape:cy="32"
+     inkscape:cx="0.81392236"
+     inkscape:cy="31.957162"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g897" />
+     inkscape:current-layer="g897"
+     inkscape:pagecheckerboard="0" />
   <g
      id="g897"
      transform="matrix(1.0862069,0,0,1.0677952,-2.7586207,-2.7033051)"

--- a/icons/icon_red.svg
+++ b/icons/icon_red.svg
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    version="1"
    id="svg883"
-   sodipodi:docname="mumble_red.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   sodipodi:docname="icon_red.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title13">icon_red.svg</title>
   <metadata
      id="metadata889">
     <rdf:RDF>
@@ -21,7 +23,21 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title>icon_red.svg</dc:title>
+        <dc:source>https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/blob/77fad87146ce97ca76fa54379a6fe16545146ab4/Papirus/64x64/apps/mumble.svg</dc:source>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>maweil</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>PapirusDevelopmentTeam</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:description>Modified version of PapirusDevelopmentTeam's mumble.svg icon (see source URL)</dc:description>
+        <cc:license
+           rdf:resource="https://spdx.org/licenses/GPL-3.0-or-later.html" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,16 +53,17 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1011"
+     inkscape:window-height="1043"
      id="namedview885"
      showgrid="false"
      inkscape:zoom="11.671875"
-     inkscape:cx="32"
-     inkscape:cy="32"
+     inkscape:cx="29.858099"
+     inkscape:cy="31.957162"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g897" />
+     inkscape:current-layer="g897"
+     inkscape:pagecheckerboard="0" />
   <g
      id="g897"
      transform="matrix(1.0862069,0,0,1.0677952,-2.7586207,-2.7033051)"

--- a/metadata.json
+++ b/metadata.json
@@ -5,9 +5,10 @@
   "settings-schema": "org.gnome.shell.extensions.mumble-ping",
   "gettext-domain": "mumble-ping",
   "url": "https://github.com/maweil/gnome-shell-extension-mumble-ping",
-  "version": 1,
+  "version": 2,
   "shell-version": [
     "3.38",
-    "40"
+    "40",
+    "41"
   ]
 }

--- a/prefs.js
+++ b/prefs.js
@@ -121,9 +121,5 @@ const MumblePingPrefsWidget = new GObject.registerClass(
 // eslint-disable-next-line no-unused-vars
 function buildPrefsWidget() {
     const prefsWidget = new MumblePingPrefsWidget();
-    if (GTK_MAJOR_VERSION < 4) {
-        prefsWidget.show_all();
-        prefsWidget.connect('destroy', Gtk.main_quit);
-    }
     return prefsWidget;
 }


### PR DESCRIPTION
This updates the extension to support GNOME Shell 41.
The version number is increased to 2.

In addition to that, a small error handling improvement was added as well as adding the sources of the original icons to the `.svg` files itself. 